### PR TITLE
Define the required Node.js version to 16.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "vue3",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": "16.x.x"
+  },
   "scripts": {
     "serve": "vite preview",
     "build": "vite build",


### PR DESCRIPTION
@yannde  Because vuejs-boilerplate is running on Node.js `v16.x.x`

I found that `yarn storybook` gives error on Node.js `v18.x.x`.
(Please refer to the following log)

```
$ node -v
v18.12.1
$ yarn storybook
yarn run v1.22.19
$ start-storybook -p 6006 -c _storybook
info @storybook/vue3 v6.5.9
info
info => Loading presets
info Found existing addon {"name":"@storybook/addon-docs","options":{"configureJSX":true,"babelOptions":{},"sourceLoaderOptions":null,"transcludeMarkdown":true}}, skipping.
info Found existing addon "@storybook/addon-controls", skipping.

info => Ignoring cached manager due to change in manager config
ℹ ｢wdm｣: wait until bundle finished:
Pre-bundling dependencies:
  @storybook/jest
  @storybook/testing-library
  storybook-vue3-router
  msw
  vue
  (...and 72 more)
(this will be run only when your dependencies or config have changed)
node:internal/crypto/hash:71
  this[kHandle] = new _Hash(algorithm, xofLen);
                  ^

Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:71:19)
    at Object.createHash (node:crypto:133:10)
    at module.exports (/private/tmp/vuejs-boilerplate/node_modules/webpack/lib/util/createHash.js:135:53)
    at NormalModule._initBuildHash (/private/tmp/vuejs-boilerplate/node_modules/webpack/lib/NormalModule.js:417:16)
    at handleParseError (/private/tmp/vuejs-boilerplate/node_modules/webpack/lib/NormalModule.js:471:10)
    at /private/tmp/vuejs-boilerplate/node_modules/webpack/lib/NormalModule.js:503:5
    at /private/tmp/vuejs-boilerplate/node_modules/webpack/lib/NormalModule.js:358:12
    at /private/tmp/vuejs-boilerplate/node_modules/loader-runner/lib/LoaderRunner.js:373:3
    at iterateNormalLoaders (/private/tmp/vuejs-boilerplate/node_modules/loader-runner/lib/LoaderRunner.js:214:10)
    at Array.<anonymous> (/private/tmp/vuejs-boilerplate/node_modules/loader-runner/lib/LoaderRunner.js:205:4)
    at Storage.finished (/private/tmp/vuejs-boilerplate/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:55:16)
    at /private/tmp/vuejs-boilerplate/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:91:9
    at /private/tmp/vuejs-boilerplate/node_modules/graceful-fs/graceful-fs.js:123:16
    at FSReqCallback.readFileAfterClose [as oncomplete] (node:internal/fs/read_file_context:68:3) {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}

Node.js v18.12.1
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

and it was working fine in Node.js v16.x.x.

```
$ node -v
v16.19.0
$ yarn storybook
yarn run v1.22.19
$ start-storybook -p 6006 -c _storybook
info @storybook/vue3 v6.5.9
info
info => Loading presets
info Found existing addon {"name":"@storybook/addon-docs","options":{"configureJSX":true,"babelOptions":{},"sourceLoaderOptions":null,"transcludeMarkdown":true}}, skipping.
info Found existing addon "@storybook/addon-controls", skipping.
(node:7200) [DEP0148] DeprecationWarning: Use of deprecated folder mapping "./" in the "exports" field module resolution of the package at /private/tmp/vuejs-boilerplate/node_modules/vuex/package.json.
Update this package.json to use a subpath pattern like "./*".
(Use `node --trace-deprecation ...` to show where the warning was created)

info => Using cached manager
╭──────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                          │
│   Storybook 6.5.9 for Vue3 started                                                       │
│   155 ms for preview                                                                     │
│                                                                                          │
│    Local:            http://localhost:6006/                                              │
│    On your network:  http://172.20.10.7:6006/                                            │
│                                                                                          │
│   A new version (6.5.14) is available!                                                   │
│                                                                                          │
│   Upgrade now: npx storybook@latest upgrade                                              │
│                                                                                          │
│   Read full changelog: https://github.com/storybookjs/storybook/blob/next/CHANGELOG.md   │
│                                                                                          │
╰──────────────────────────────────────────────────────────────────────────────────────────╯

```